### PR TITLE
Dockerfile image hygiene: shallow upstream fetch + drop .git from fin…

### DIFF
--- a/DeepSelectNet/Dockerfile.cpu
+++ b/DeepSelectNet/Dockerfile.cpu
@@ -10,9 +10,12 @@ RUN apt-get update && \
 	git
 
 ARG UPSTREAM_REF=66429a8
-RUN git clone https://github.com/AnjanaSenanayake/DeepSelectNet && \
-	cd DeepSelectNet && \
-	git checkout ${UPSTREAM_REF}
+RUN mkdir DeepSelectNet && cd DeepSelectNet && \
+	git init && \
+	git remote add origin https://github.com/AnjanaSenanayake/DeepSelectNet && \
+	git fetch --depth 1 origin ${UPSTREAM_REF} && \
+	git checkout FETCH_HEAD && \
+	rm -rf .git
 
 RUN pip3 install -r ./DeepSelectNet/requirements.txt \
 	# Workaround "generated code is out of date and must be regenerated with protoc >= 3.19.0" error in trainer.py

--- a/DeepSelectNet/Dockerfile.cpu
+++ b/DeepSelectNet/Dockerfile.cpu
@@ -9,7 +9,7 @@ RUN apt-get update && \
 	gcc \
 	git
 
-ARG UPSTREAM_REF=66429a8
+ARG UPSTREAM_REF=66429a8608fbf59f34bdcd2609b3931c145501fb
 RUN mkdir DeepSelectNet && cd DeepSelectNet && \
 	git init && \
 	git remote add origin https://github.com/AnjanaSenanayake/DeepSelectNet && \

--- a/DeepSelectNet/Dockerfile.gpu
+++ b/DeepSelectNet/Dockerfile.gpu
@@ -24,9 +24,12 @@ RUN cd /usr/src && \
 # Clone git repo
 RUN apt-get install -y git
 ARG UPSTREAM_REF=66429a8
-RUN git clone https://github.com/AnjanaSenanayake/DeepSelectNet && \
-    cd DeepSelectNet && \
-    git checkout ${UPSTREAM_REF}
+RUN mkdir DeepSelectNet && cd DeepSelectNet && \
+    git init && \
+    git remote add origin https://github.com/AnjanaSenanayake/DeepSelectNet && \
+    git fetch --depth 1 origin ${UPSTREAM_REF} && \
+    git checkout FETCH_HEAD && \
+    rm -rf .git
 
 # Install python libraries
 RUN pip3 install --upgrade pip

--- a/DeepSelectNet/Dockerfile.gpu
+++ b/DeepSelectNet/Dockerfile.gpu
@@ -23,7 +23,7 @@ RUN cd /usr/src && \
 
 # Clone git repo
 RUN apt-get install -y git
-ARG UPSTREAM_REF=66429a8
+ARG UPSTREAM_REF=66429a8608fbf59f34bdcd2609b3931c145501fb
 RUN mkdir DeepSelectNet && cd DeepSelectNet && \
     git init && \
     git remote add origin https://github.com/AnjanaSenanayake/DeepSelectNet && \

--- a/README.md
+++ b/README.md
@@ -5,45 +5,54 @@ Docker containers for tools used in nanopore signal-level ("squiggle") analysis.
 Each top-level directory is a self-contained build for one upstream project.
 Images are built by CI and published to GitHub Container Registry.
 
-## Available tools
-
-### Mapping
-
-- [RawAlign](https://github.com/CMU-SAFARI/RawAlign)
-- [UNCALLED](https://github.com/skovaka/UNCALLED) (different from UNCALLED 4)
-- [UNCALLED 4](https://github.com/skovaka/uncalled4)
-- [Sigmap](https://github.com/haowenz/sigmap)
-- [RawHash](https://github.com/CMU-SAFARI/RawHash)
-
-### Classification
-
-- [Sigmoni](https://github.com/vshiv18/sigmoni)
-- [SquiggleNet](https://github.com/welch-lab/SquiggleNet)
-- [ReadCurrent](https://github.com/Ming-Ni-Group/ReadCurrent)
-- [RISER](https://github.com/comprna/riser)
-- [DeepSelectNet](https://github.com/AnjanaSenanayake/DeepSelectNet)
-
-## Docker images
-
-CI publishes images to GHCR on every push to `main` and on manual dispatch.
-Pull requests are built but not pushed.
-
-Tag format:
-
-```
-ghcr.io/<owner>/<tool>:<short-sha>
-ghcr.io/<owner>/<tool>:latest
-```
-
-`<owner>` is the lowercased GitHub owner of this repo (e.g. `squidbase`) and
-`<short-sha>` is the short commit SHA of `nanopore-tools` at build time.
-
-Example:
+## Quick start
 
 ```
 docker pull ghcr.io/squidbase/uncalled:latest
 docker run --rm -it ghcr.io/squidbase/uncalled:latest --help
 ```
+
+## Versioning
+
+Two independent things are pinned for every image:
+
+- **Image tag** — set by CI to the short SHA of this repo at build time, plus
+  `:latest`. Format: `ghcr.io/squidbase/<tool>:<short-sha>` and
+  `ghcr.io/squidbase/<tool>:latest`. Every push to `main` produces a fresh
+  pair; PR builds verify but don't push.
+- **Upstream tool pin** — each Dockerfile fetches its upstream source at a
+  specific commit via `ARG UPSTREAM_REF=<full-sha>`. Override at build time
+  with `--build-arg UPSTREAM_REF=<sha>` (see [Building locally](#building-locally)).
+
+To pin a deployment, use the short-SHA tag (e.g.
+`ghcr.io/squidbase/uncalled:9dcb4ea`) rather than `:latest`. The short SHA
+identifies the exact Dockerfile and upstream pin used.
+
+## Available tools
+
+All images live under `ghcr.io/squidbase/`. The "Pull" column shows the
+matching tag; substitute `:latest` with a specific `<short-sha>` to pin.
+
+### Mapping
+
+| Tool | Upstream | Pull |
+|---|---|---|
+| UNCALLED | [skovaka/UNCALLED](https://github.com/skovaka/UNCALLED) | `docker pull ghcr.io/squidbase/uncalled:latest` |
+| UNCALLED 4 | [skovaka/uncalled4](https://github.com/skovaka/uncalled4) | `docker pull ghcr.io/squidbase/uncalled4:latest` |
+| RawAlign | [CMU-SAFARI/RawAlign](https://github.com/CMU-SAFARI/RawAlign) | `docker pull ghcr.io/squidbase/rawalign:latest` |
+| RawHash | [CMU-SAFARI/RawHash](https://github.com/CMU-SAFARI/RawHash) | `docker pull ghcr.io/squidbase/rawhash2:latest` |
+| Sigmap | [haowenz/sigmap](https://github.com/haowenz/sigmap) | `docker pull ghcr.io/squidbase/sigmap:latest` |
+
+### Classification
+
+| Tool | Upstream | Pull |
+|---|---|---|
+| Sigmoni | [vshiv18/sigmoni](https://github.com/vshiv18/sigmoni) | `docker pull ghcr.io/squidbase/sigmoni:latest` |
+| SquiggleNet | [welch-lab/SquiggleNet](https://github.com/welch-lab/SquiggleNet) | `docker pull ghcr.io/squidbase/squigglenet:latest` |
+| ReadCurrent | [Ming-Ni-Group/ReadCurrent](https://github.com/Ming-Ni-Group/ReadCurrent) | `docker pull ghcr.io/squidbase/readcurrent:latest` |
+| RISER | [comprna/riser](https://github.com/comprna/riser) | `docker pull ghcr.io/squidbase/riser:latest` |
+| DeepSelectNet (CPU) | [AnjanaSenanayake/DeepSelectNet](https://github.com/AnjanaSenanayake/DeepSelectNet) | `docker pull ghcr.io/squidbase/deepselectnet-cpu:latest` |
+| DeepSelectNet (GPU) | [AnjanaSenanayake/DeepSelectNet](https://github.com/AnjanaSenanayake/DeepSelectNet) | `docker pull ghcr.io/squidbase/deepselectnet-gpu:latest` |
 
 ## Building locally
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ Images are built by CI and published to GitHub Container Registry.
 
 ```
 docker pull ghcr.io/squidbase/uncalled:latest
-docker run --rm -it ghcr.io/squidbase/uncalled:latest --help
+docker run --rm -it ghcr.io/squidbase/uncalled:latest uncalled --help
 ```
+
+Most images set `ENTRYPOINT []`, so pass the tool's executable name as the
+first argument (e.g. `uncalled`, `rawalign`, `sigmap`). A few are
+pre-configured with an entrypoint (e.g. `uncalled4`) and accept the
+tool's flags directly.
 
 ## Versioning
 
@@ -75,13 +80,18 @@ To keep builds reproducible, fast, and free of upstream VCS metadata, every
 Dockerfile fetches its tool with a shallow, single-commit fetch of a pinned ref:
 
 ```
-ARG UPSTREAM_REF=<commit-sha>
+ARG UPSTREAM_REF=<full-40-char-sha>
 RUN git init . \
     && git remote add origin https://github.com/<org>/<repo> \
     && git fetch --depth 1 origin ${UPSTREAM_REF} \
     && git checkout FETCH_HEAD \
     && rm -rf .git
 ```
+
+> **`UPSTREAM_REF` must be a full 40-character commit SHA.** GitHub's smart
+> HTTP protocol only resolves arbitrary commits by their full SHA — an
+> abbreviated 7-char SHA fails with `couldn't find remote ref`. A branch or
+> tag name also works.
 
 Notes:
 
@@ -121,7 +131,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends build-essential git \
  && rm -rf /var/lib/apt/lists/*
 
-ARG UPSTREAM_REF=<commit-sha>
+ARG UPSTREAM_REF=<full-40-char-sha>
 RUN git init . \
     && git remote add origin https://github.com/<org>/<repo> \
     && git fetch --depth 1 origin ${UPSTREAM_REF} \
@@ -136,7 +146,8 @@ Conventions:
 - Prefer multi-stage builds for compiled tools so the final image only carries
   the built artifacts.
 - Add a non-root `user` and `WORKDIR /workspace` in the final stage.
-- Pin `UPSTREAM_REF` to a specific commit SHA, not a branch name.
+- Pin `UPSTREAM_REF` to the **full 40-char commit SHA** (or a tag), not a
+  branch name. Abbreviated SHAs fail with `git fetch --depth 1`.
 
 ### 3. Wire the tool into CI
 

--- a/README.md
+++ b/README.md
@@ -1,67 +1,187 @@
 # nanopore-tools
 
-## squiggle matching tools Roadmap
+Docker containers for tools used in nanopore signal-level ("squiggle") analysis.
 
-This roadmap outlines our plan to focus on creating Docker containers for a variety of tools dedicated to signal matching, commonly known as squiggle matching. These tools are essential for analyzing raw signal data in genomics and other fields. Below are the tools we plan to work on, with links to their respective repositories or relevant resources, where applicable.
+Each top-level directory is a self-contained build for one upstream project.
+Images are built by CI and published to GitHub Container Registry.
+
+## Available tools
 
 ### Mapping
 
-#### Rawalign
-[Rawalign](https://github.com/CMU-SAFARI/RawAlign) 
-
-#### UNCALLED (different from UNCALLED4)
-[UNCALLED](https://github.com/skovaka/UNCALLED)
-
-#### UNCALLED 4
-[UNCALLED 4](https://github.com/skovaka/uncalled4)
-
-#### Sigmap
-[SigMap](https://github.com/haowenz/sigmap)
-
-#### RawHash
-[RawHash](https://github.com/CMU-SAFARI/RawHash) 
+- [RawAlign](https://github.com/CMU-SAFARI/RawAlign)
+- [UNCALLED](https://github.com/skovaka/UNCALLED) (different from UNCALLED 4)
+- [UNCALLED 4](https://github.com/skovaka/uncalled4)
+- [Sigmap](https://github.com/haowenz/sigmap)
+- [RawHash](https://github.com/CMU-SAFARI/RawHash)
 
 ### Classification
 
-#### Sigmoni
-[Sigmoni](https://github.com/vshiv18/sigmoni).
+- [Sigmoni](https://github.com/vshiv18/sigmoni)
+- [SquiggleNet](https://github.com/welch-lab/SquiggleNet)
+- [ReadCurrent](https://github.com/Ming-Ni-Group/ReadCurrent)
+- [RISER](https://github.com/comprna/riser)
+- [DeepSelectNet](https://github.com/AnjanaSenanayake/DeepSelectNet)
 
-#### BaseLess
-[BaseLess](https://github.com/cvdelannoy/baseLess)
+## Docker images
 
-#### SquiggleNet
-[SquiggleNet](https://github.com/welch-lab/SquiggleNet)
+CI publishes images to GHCR on every push to `main` and on manual dispatch.
+Pull requests are built but not pushed.
 
-#### ReadCurrent
-[ReadCurrent](https://github.com/Ming-Ni-Group/ReadCurrent)
-
-#### RISER
-[RISER](https://github.com/comprna/riser)
-
-
-## 🐳 Docker Tag Format
-
-Some Docker image is tagged with:
-
-* The version of the tool (from its Git history)
-* The version of the main repo: [`SquiDBase/nanopore-tools`](https://github.com/SquiDBase/nanopore-tools)
-
-### 🔖 Format
+Tag format:
 
 ```
-haliliceylanua/<tool-name>:<tool-version>-<main-repo-commit>
+ghcr.io/<owner>/<tool>:<short-sha>
+ghcr.io/<owner>/<tool>:latest
 ```
 
-### 🧪 Example
+`<owner>` is the lowercased GitHub owner of this repo (e.g. `squidbase`) and
+`<short-sha>` is the short commit SHA of `nanopore-tools` at build time.
+
+Example:
 
 ```
-haliliceylanua/uncalled:v2.3-3-g58dbec6-9e989bb
+docker pull ghcr.io/squidbase/uncalled:latest
+docker run --rm -it ghcr.io/squidbase/uncalled:latest --help
 ```
 
-### 🔍 Breakdown
+## Building locally
 
-* `v2.3-3-g58dbec6`: from the tool’s Git (e.g., `UNCALLED`)
+Each Dockerfile pins its upstream source through an `ARG UPSTREAM_REF`. Build
+with the default pin:
 
-  * 3 commits after tag `v2.3`
-  * Commit `58dbec6`
-* `9e989bb`: commit from `nanopore-tools` (main repo)
+```
+docker build -t my-uncalled Uncalled
+```
+
+…or build against a different upstream commit:
+
+```
+docker build --build-arg UPSTREAM_REF=<commit-sha> -t my-uncalled Uncalled
+```
+
+## Upstream source pinning
+
+To keep builds reproducible, fast, and free of upstream VCS metadata, every
+Dockerfile fetches its tool with a shallow, single-commit fetch of a pinned ref:
+
+```
+ARG UPSTREAM_REF=<commit-sha>
+RUN git init . \
+    && git remote add origin https://github.com/<org>/<repo> \
+    && git fetch --depth 1 origin ${UPSTREAM_REF} \
+    && git checkout FETCH_HEAD \
+    && rm -rf .git
+```
+
+Notes:
+
+- Drop `rm -rf .git` if the stage is intermediate and nothing copies the
+  working tree into the final image (multi-stage builds that only copy built
+  artifacts via `COPY --from=build`).
+- Drop `rm -rf .git` if the build needs `.git` later (e.g. `git submodule
+  update`). In that case, do the submodule init **before** any subsequent
+  removal, or rely on a multi-stage build to discard `.git` for you.
+- For repos with submodules, append `&& git submodule update --init
+  --recursive --depth=1` to the same RUN.
+- Make sure the base image has `git` installed (most slim/distroless ones
+  don't — add it to your `apt-get install` or `apk add` list).
+
+## Adding a new tool
+
+Follow these steps to add a new tool to the repo and CI pipeline.
+
+### 1. Create the tool directory
+
+Create a top-level directory named after the tool (PascalCase to match the
+upstream project's name is fine — e.g. `NewTool/`). Anything the build needs
+that isn't in upstream (patch files, modified scripts, an `environment.yml`)
+lives in that directory and is referenced relatively from the Dockerfile.
+
+### 2. Write the Dockerfile
+
+Place `NewTool/Dockerfile` (or `Dockerfile.cpu` / `Dockerfile.gpu` for split
+builds). Follow the canonical pattern:
+
+```Dockerfile
+FROM <base-image> AS build
+
+WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential git \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG UPSTREAM_REF=<commit-sha>
+RUN git init . \
+    && git remote add origin https://github.com/<org>/<repo> \
+    && git fetch --depth 1 origin ${UPSTREAM_REF} \
+    && git checkout FETCH_HEAD \
+    && rm -rf .git
+
+# …tool-specific build steps…
+```
+
+Conventions:
+
+- Prefer multi-stage builds for compiled tools so the final image only carries
+  the built artifacts.
+- Add a non-root `user` and `WORKDIR /workspace` in the final stage.
+- Pin `UPSTREAM_REF` to a specific commit SHA, not a branch name.
+
+### 3. Wire the tool into CI
+
+Edit `.github/workflows/docker.yml`. Two places need a matching entry — the
+**path filter** name and the **matrix** name must be identical.
+
+**a. Path filter** — under `steps.filter.with.filters`, add:
+
+```yaml
+newtool:
+  - 'NewTool/**'
+```
+
+**b. Build matrix** — inside the `ALL` JSON array in the `Build matrix` step,
+add an entry:
+
+```json
+{"name":"newtool","dockerfile":"NewTool/Dockerfile","context":"NewTool"}
+```
+
+If the tool has both CPU and GPU variants (like `DeepSelectNet`), add two
+matrix entries and two path filter entries that point to the same directory:
+
+```yaml
+newtool-cpu:
+  - 'NewTool/**'
+newtool-gpu:
+  - 'NewTool/**'
+```
+
+```json
+{"name":"newtool-cpu","dockerfile":"NewTool/Dockerfile.cpu","context":"NewTool"},
+{"name":"newtool-gpu","dockerfile":"NewTool/Dockerfile.gpu","context":"NewTool"}
+```
+
+The `name` field becomes the image name on GHCR
+(`ghcr.io/<owner>/<name>:<tag>`), so pick something short and lowercase.
+
+### 4. Verify the build
+
+- Open a PR. The `detect-changes` job will pick up your new directory via the
+  path filter and run the matching matrix entry. PR builds don't push — they
+  only verify that the image builds.
+- After merge to `main`, the image is built again and pushed to GHCR with both
+  `:<short-sha>` and `:latest` tags.
+
+### Triggering a manual build
+
+The workflow also supports `workflow_dispatch`. From the Actions tab, run
+"Build and push Docker images" with the `tools` input set to a
+comma-separated list of matrix `name`s — or `all` to rebuild everything:
+
+```
+all
+uncalled,rawalign
+deepselectnet-cpu
+```

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ docker pull ghcr.io/squidbase/uncalled:latest
 docker run --rm -it ghcr.io/squidbase/uncalled:latest uncalled --help
 ```
 
-Most images set `ENTRYPOINT []`, so pass the tool's executable name as the
-first argument (e.g. `uncalled`, `rawalign`, `sigmap`). A few are
-pre-configured with an entrypoint (e.g. `uncalled4`) and accept the
-tool's flags directly.
+Entrypoint behavior varies by image. For portability, invoke the executable
+explicitly (e.g. `uncalled --help`, `rawalign --help`, `sigmap --help`).
+Some images define an entrypoint (e.g. `uncalled4`) and accept flags directly.
 
 ## Versioning
 
@@ -76,8 +75,8 @@ docker build --build-arg UPSTREAM_REF=<commit-sha> -t my-uncalled Uncalled
 
 ## Upstream source pinning
 
-To keep builds reproducible, fast, and free of upstream VCS metadata, every
-Dockerfile fetches its tool with a shallow, single-commit fetch of a pinned ref:
+To keep builds reproducible, fast, and free of upstream VCS metadata, use this
+preferred pattern (already adopted by many Dockerfiles in this repo):
 
 ```
 ARG UPSTREAM_REF=<full-40-char-sha>
@@ -88,10 +87,9 @@ RUN git init . \
     && rm -rf .git
 ```
 
-> **`UPSTREAM_REF` must be a full 40-character commit SHA.** GitHub's smart
-> HTTP protocol only resolves arbitrary commits by their full SHA — an
-> abbreviated 7-char SHA fails with `couldn't find remote ref`. A branch or
-> tag name also works.
+> For this shallow-fetch pattern, **`UPSTREAM_REF` should be a full 40-character
+> commit SHA** (or a branch/tag ref). Abbreviated SHAs can fail with
+> `couldn't find remote ref`.
 
 Notes:
 
@@ -146,8 +144,8 @@ Conventions:
 - Prefer multi-stage builds for compiled tools so the final image only carries
   the built artifacts.
 - Add a non-root `user` and `WORKDIR /workspace` in the final stage.
-- Pin `UPSTREAM_REF` to the **full 40-char commit SHA** (or a tag), not a
-  branch name. Abbreviated SHAs fail with `git fetch --depth 1`.
+- For the shallow-fetch pattern above, pin `UPSTREAM_REF` to the
+  **full 40-char commit SHA** (or use a tag/branch ref).
 
 ### 3. Wire the tool into CI
 

--- a/RISER/Dockerfile
+++ b/RISER/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 # Clone RISER and install requirements
-ARG UPSTREAM_REF=d3410a6
+ARG UPSTREAM_REF=d3410a6da26a6fa1222f67ca8d73a48cdc58c6d6
 RUN mkdir riser && cd riser && \
     git init && \
     git remote add origin https://github.com/comprna/riser && \

--- a/RISER/Dockerfile
+++ b/RISER/Dockerfile
@@ -11,9 +11,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Clone RISER and install requirements
 ARG UPSTREAM_REF=d3410a6
-RUN git clone https://github.com/comprna/riser riser && \
-    cd riser && \
-    git checkout ${UPSTREAM_REF} && \
+RUN mkdir riser && cd riser && \
+    git init && \
+    git remote add origin https://github.com/comprna/riser && \
+    git fetch --depth 1 origin ${UPSTREAM_REF} && \
+    git checkout FETCH_HEAD && \
+    rm -rf .git && \
     pip install --upgrade pip && \
     pip install --prefix=/opt/riser -r requirements.txt
 

--- a/RawAlign/Dockerfile
+++ b/RawAlign/Dockerfile
@@ -10,8 +10,10 @@ RUN  apt-get update \
 ENV HDF5_PLUGIN_PATH=/path/to/hdf5/plugins/lib
 
 ARG UPSTREAM_REF=ee59c4e
-RUN git clone https://github.com/cmu-safari/RawAlign . \
-    && git checkout ${UPSTREAM_REF} \
+RUN git init . \
+    && git remote add origin https://github.com/cmu-safari/RawAlign \
+    && git fetch --depth 1 origin ${UPSTREAM_REF} \
+    && git checkout FETCH_HEAD \
     && git submodule update --init --recursive --depth=1
 
 RUN make

--- a/RawAlign/Dockerfile
+++ b/RawAlign/Dockerfile
@@ -9,7 +9,7 @@ RUN  apt-get update \
 
 ENV HDF5_PLUGIN_PATH=/path/to/hdf5/plugins/lib
 
-ARG UPSTREAM_REF=ee59c4e
+ARG UPSTREAM_REF=ee59c4e5d04d8464e134fe5c0c9e1cd38ccc9cc3
 RUN git init . \
     && git remote add origin https://github.com/cmu-safari/RawAlign \
     && git fetch --depth 1 origin ${UPSTREAM_REF} \

--- a/RawHash2/Dockerfile
+++ b/RawHash2/Dockerfile
@@ -14,11 +14,13 @@ RUN apt-get update && \
 
 ENV HDF5_PLUGIN_PATH=/path/to/hdf5/plugins/lib
 
-ARG UPSTREAM_REF=d3956ea
-RUN git clone https://github.com/CMU-SAFARI/RawHash \
-    && cd RawHash \
-    && git checkout ${UPSTREAM_REF} \
-    && git submodule update --init --recursive --depth 1
+ARG UPSTREAM_REF=d3956eaf261588555fa884c5c294fd46df591851
+RUN mkdir RawHash && cd RawHash \
+    && git init . \
+    && git remote add origin https://github.com/CMU-SAFARI/RawHash \
+    && git fetch --depth 1 origin ${UPSTREAM_REF} \
+    && git checkout FETCH_HEAD \
+    && git submodule update --init --recursive --depth=1
 
 
 RUN cd ./RawHash && make

--- a/ReadCurrent/Dockerfile
+++ b/ReadCurrent/Dockerfile
@@ -5,9 +5,13 @@ SHELL ["/bin/bash", "--login", "-c"]
 WORKDIR /app
 
 # Clone repository
-ARG UPSTREAM_REF=6db8921
-RUN git clone https://github.com/Ming-Ni-Group/ReadCurrent.git /app/ReadCurrent && \
-    git -C /app/ReadCurrent checkout ${UPSTREAM_REF}
+ARG UPSTREAM_REF=6db8921fdc04236dd23a11a951a25ccc0965ae72
+RUN mkdir -p /app/ReadCurrent && cd /app/ReadCurrent && \
+    git init . && \
+    git remote add origin https://github.com/Ming-Ni-Group/ReadCurrent && \
+    git fetch --depth 1 origin ${UPSTREAM_REF} && \
+    git checkout FETCH_HEAD && \
+    rm -rf .git
 
 # Extend tester script to make it more verbose
 RUN apt-get update && apt-get install -y patch && rm -rf /var/lib/apt/lists/*

--- a/Sigmap/Dockerfile
+++ b/Sigmap/Dockerfile
@@ -14,11 +14,13 @@ RUN apt-get update && \
 
 ENV HDF5_PLUGIN_PATH=/path/to/hdf5/plugins/lib
 
-ARG UPSTREAM_REF=c9a4048
-RUN git clone https://github.com/haowenz/sigmap \
-    && cd sigmap \
-    && git checkout ${UPSTREAM_REF} \
-    && git submodule update --init --recursive --depth 1
+ARG UPSTREAM_REF=c9a40483264c9514587a36555b5af48d3f054f6f
+RUN mkdir sigmap && cd sigmap \
+    && git init . \
+    && git remote add origin https://github.com/haowenz/sigmap \
+    && git fetch --depth 1 origin ${UPSTREAM_REF} \
+    && git checkout FETCH_HEAD \
+    && git submodule update --init --recursive --depth=1
 
 RUN cd ./sigmap && make
 

--- a/Sigmoni/Dockerfile
+++ b/Sigmoni/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y --no-install-recommends build-essential gcc git
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-ARG UPSTREAM_REF=5c6383a
+ARG UPSTREAM_REF=5c6383abcf6db2a1fd5531ecfbfc316c3ab52a6a
 RUN git init . \
     && git remote add origin https://github.com/vshiv18/sigmoni \
     && git fetch --depth 1 origin ${UPSTREAM_REF} \

--- a/Sigmoni/Dockerfile
+++ b/Sigmoni/Dockerfile
@@ -15,8 +15,11 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 ARG UPSTREAM_REF=5c6383a
-RUN git clone https://github.com/vshiv18/sigmoni . \
-    && git checkout ${UPSTREAM_REF}
+RUN git init . \
+    && git remote add origin https://github.com/vshiv18/sigmoni \
+    && git fetch --depth 1 origin ${UPSTREAM_REF} \
+    && git checkout FETCH_HEAD \
+    && rm -rf .git
 
 RUN cd src/delta_rust && \
     cargo build --release && \

--- a/SquiggleNet/Dockerfile
+++ b/SquiggleNet/Dockerfile
@@ -13,7 +13,7 @@ RUN pip3 install scipy numpy click ont-fast5-api
 
 RUN pip3 install typing-extensions --upgrade
 
-ARG UPSTREAM_REF=fb7b206
+ARG UPSTREAM_REF=fb7b206e05935de48895cdbd16a7c1df73515202
 RUN mkdir SquiggleNet && cd SquiggleNet && \
     git init && \
     git remote add origin https://github.com/welch-lab/SquiggleNet && \

--- a/SquiggleNet/Dockerfile
+++ b/SquiggleNet/Dockerfile
@@ -3,8 +3,9 @@ FROM --platform=linux/amd64 python:3.11 AS build
 
 WORKDIR /app
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends build-essential gcc git
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential gcc git \
+    && rm -rf /var/lib/apt/lists/*
 
 # PyTorch CPU version (or should the container support GPU?)
 RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu

--- a/SquiggleNet/Dockerfile
+++ b/SquiggleNet/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=linux/amd64 python:3.11 AS build
 WORKDIR /app
 
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends build-essential gcc
+RUN apt-get install -y --no-install-recommends build-essential gcc git
 
 # PyTorch CPU version (or should the container support GPU?)
 RUN pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
@@ -14,9 +14,12 @@ RUN pip3 install scipy numpy click ont-fast5-api
 RUN pip3 install typing-extensions --upgrade
 
 ARG UPSTREAM_REF=fb7b206
-RUN git clone https://github.com/welch-lab/SquiggleNet && \
-    cd SquiggleNet && \
-    git checkout ${UPSTREAM_REF}
+RUN mkdir SquiggleNet && cd SquiggleNet && \
+    git init && \
+    git remote add origin https://github.com/welch-lab/SquiggleNet && \
+    git fetch --depth 1 origin ${UPSTREAM_REF} && \
+    git checkout FETCH_HEAD && \
+    rm -rf .git
 
 RUN useradd -m user
 

--- a/Uncalled/Dockerfile
+++ b/Uncalled/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential gcc wget git
 
-ARG UPSTREAM_REF=58dbec6
+ARG UPSTREAM_REF=58dbec69f625e0343739d821788d536b578ea41d
 RUN git init . \
     && git remote add origin https://github.com/skovaka/UNCALLED \
     && git fetch --depth 1 origin ${UPSTREAM_REF} \

--- a/Uncalled/Dockerfile
+++ b/Uncalled/Dockerfile
@@ -7,8 +7,10 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential gcc wget git
 
 ARG UPSTREAM_REF=58dbec6
-RUN git clone https://github.com/skovaka/UNCALLED . \
-    && git checkout ${UPSTREAM_REF} \
+RUN git init . \
+    && git remote add origin https://github.com/skovaka/UNCALLED \
+    && git fetch --depth 1 origin ${UPSTREAM_REF} \
+    && git checkout FETCH_HEAD \
     && git submodule update --init --recursive --depth=1
 
 RUN pip install --user .

--- a/Uncalled4/Dockerfile
+++ b/Uncalled4/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends build-essential gcc git
 
 
-ARG UPSTREAM_REF=679e37b
+ARG UPSTREAM_REF=679e37b62027051e89030dc57619aa7c10d7115a
 RUN git init . \
     && git remote add origin https://github.com/skovaka/uncalled4 \
     && git fetch --depth 1 origin ${UPSTREAM_REF} \

--- a/Uncalled4/Dockerfile
+++ b/Uncalled4/Dockerfile
@@ -42,8 +42,10 @@ RUN apt-get install -y --no-install-recommends build-essential gcc git
 
 
 ARG UPSTREAM_REF=679e37b
-RUN git clone https://github.com/skovaka/uncalled4 . \
-    && git checkout ${UPSTREAM_REF}
+RUN git init . \
+    && git remote add origin https://github.com/skovaka/uncalled4 \
+    && git fetch --depth 1 origin ${UPSTREAM_REF} \
+    && git checkout FETCH_HEAD
 
 RUN pip install --user .
 


### PR DESCRIPTION
…al images

- Replace full git clone with: git init + git fetch --depth 1 of UPSTREAM_REF
  + git checkout FETCH_HEAD. Faster builds, smaller layer.
- rm -rf .git after checkout where the working tree ends up in the final image (SquiggleNet, RISER, Sigmoni, DeepSelectNet CPU/GPU) to avoid shipping VCS metadata.
- Add git to SquiggleNet apt-get install (don't rely on base image).
- Multi-stage builds that only copy built artifacts (Uncalled, Uncalled4, RawAlign) keep .git in the build stage where it's needed for submodules.

Also rewrite README:
- Update Docker image section for GHCR tag format used by current CI.
- Document the upstream-pinning pattern and when to drop .git.
- Add an "Adding a new tool" guide covering the Dockerfile template and the two matching CI entries (path filter + matrix) needed in .github/workflows/docker.yml.