### PR TITLE
Fix AVX-512/-march=native crash on non-AVX-512 CPUs (e.g. Zen 3)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,10 +70,14 @@ jobs:
           ALL='[
             {"name":"uncalled","dockerfile":"Uncalled/Dockerfile","context":"Uncalled"},
             {"name":"uncalled4","dockerfile":"Uncalled4/Dockerfile","context":"Uncalled4"},
-            {"name":"rawalign","dockerfile":"RawAlign/Dockerfile","context":"RawAlign"},
-            {"name":"sigmoni","dockerfile":"Sigmoni/Dockerfile","context":"Sigmoni"},
-            {"name":"rawhash2","dockerfile":"RawHash2/Dockerfile","context":"RawHash2"},
-            {"name":"sigmap","dockerfile":"Sigmap/Dockerfile","context":"Sigmap"},
+            {"name":"rawalign","dockerfile":"RawAlign/Dockerfile","context":"RawAlign","target_arch":"x86-64-v3","image_suffix":""},
+            {"name":"rawalign","dockerfile":"RawAlign/Dockerfile","context":"RawAlign","target_arch":"x86-64-v4","image_suffix":"-avx512"},
+            {"name":"sigmoni","dockerfile":"Sigmoni/Dockerfile","context":"Sigmoni","target_arch":"x86-64-v3","image_suffix":""},
+            {"name":"sigmoni","dockerfile":"Sigmoni/Dockerfile","context":"Sigmoni","target_arch":"x86-64-v4","image_suffix":"-avx512"},
+            {"name":"rawhash2","dockerfile":"RawHash2/Dockerfile","context":"RawHash2","target_arch":"x86-64-v3","image_suffix":""},
+            {"name":"rawhash2","dockerfile":"RawHash2/Dockerfile","context":"RawHash2","target_arch":"x86-64-v4","image_suffix":"-avx512"},
+            {"name":"sigmap","dockerfile":"Sigmap/Dockerfile","context":"Sigmap","target_arch":"x86-64-v3","image_suffix":""},
+            {"name":"sigmap","dockerfile":"Sigmap/Dockerfile","context":"Sigmap","target_arch":"x86-64-v4","image_suffix":"-avx512"},
             {"name":"squigglenet","dockerfile":"SquiggleNet/Dockerfile","context":"SquiggleNet"},
             {"name":"riser","dockerfile":"RISER/Dockerfile","context":"RISER"},
             {"name":"readcurrent","dockerfile":"ReadCurrent/Dockerfile","context":"ReadCurrent"},
@@ -100,7 +104,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build-and-push:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.name }}${{ matrix.image_suffix || '' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.any == 'true'
     runs-on: ubuntu-latest
@@ -116,12 +120,15 @@ jobs:
           set -euo pipefail
           TAG=$(git rev-parse --short HEAD)
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          SUFFIX="${{ matrix.image_suffix }}"
           {
             echo "tag=${TAG}"
             echo "owner=${OWNER}"
+            echo "image_name=${{ matrix.name }}${SUFFIX}"
           } >> "$GITHUB_OUTPUT"
           echo "Tag: $TAG"
           echo "Owner: $OWNER"
+          echo "Image: ${{ matrix.name }}${SUFFIX}"
 
       - uses: docker/setup-buildx-action@v3
 
@@ -141,8 +148,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64
           provenance: false
+          build-args: |
+            TARGET_ARCH=${{ matrix.target_arch || 'x86-64-v3' }}
           tags: |
-            ghcr.io/${{ steps.ver.outputs.owner }}/${{ matrix.name }}:${{ steps.ver.outputs.tag }}
-            ghcr.io/${{ steps.ver.outputs.owner }}/${{ matrix.name }}:latest
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+            ghcr.io/${{ steps.ver.outputs.owner }}/${{ steps.ver.outputs.image_name }}:${{ steps.ver.outputs.tag }}
+            ghcr.io/${{ steps.ver.outputs.owner }}/${{ steps.ver.outputs.image_name }}:latest
+          cache-from: type=gha,scope=${{ matrix.name }}${{ matrix.image_suffix || '' }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}${{ matrix.image_suffix || '' }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ To pin a deployment, use the short-SHA tag (e.g.
 `ghcr.io/squidbase/uncalled:9dcb4ea`) rather than `:latest`. The short SHA
 identifies the exact Dockerfile and upstream pin used.
 
+For the four compiled C/C++ tools (`rawalign`, `rawhash2`, `sigmap`,
+`sigmoni`), CI now publishes two image families:
+
+- `:<short-sha>` / `:latest` for the portable baseline build (`-march=x86-64-v3`)
+- `-avx512:<short-sha>` / `-avx512:latest` for AVX-512-capable systems
+
+The portable images are the default and are the safe choice for Zen 3 and most
+general-purpose x86-64 hosts.
+
 ## Available tools
 
 All images live under `ghcr.io/squidbase/`. The "Pull" column shows the
@@ -71,6 +80,14 @@ docker build -t my-uncalled Uncalled
 
 ```
 docker build --build-arg UPSTREAM_REF=<commit-sha> -t my-uncalled Uncalled
+```
+
+For the compiled tools, you can also choose the ISA baseline at build time with
+`TARGET_ARCH` when building locally. The default is the portable `x86-64-v3`
+baseline; use `x86-64-v4` or `znver4` only when building an AVX-512 variant.
+
+```
+docker build --build-arg TARGET_ARCH=x86-64-v4 -t my-rawhash2 RawHash2
 ```
 
 ## Upstream source pinning
@@ -146,6 +163,11 @@ Conventions:
 - Add a non-root `user` and `WORKDIR /workspace` in the final stage.
 - For the shallow-fetch pattern above, pin `UPSTREAM_REF` to the
   **full 40-char commit SHA** (or use a tag/branch ref).
+
+If you add a new compiled tool that should have both portable and AVX-512
+variants, wire two matrix entries into `.github/workflows/docker.yml`: one with
+`TARGET_ARCH=x86-64-v3` and one with `TARGET_ARCH=x86-64-v4`, and give the
+AVX-512 image an `-avx512` name suffix.
 
 ### 3. Wire the tool into CI
 

--- a/RawAlign/Dockerfile
+++ b/RawAlign/Dockerfile
@@ -15,13 +15,9 @@ RUN git init . \
     && git submodule update --init --recursive --depth=1
 
 # --- Portability fix (see RawHash2/Dockerfile for rationale) ---------------
-# RawAlign's MODE=default appends -march=native. Wrappers append a portable
-# baseline last so it wins regardless of MODE.
+# RawAlign's MODE=default appends -march=native. Patch it in-place after clone.
 ARG TARGET_ARCH=x86-64-v3
-RUN for c in gcc g++ cc c++; do \
-      printf '#!/bin/sh\nexec /usr/bin/%s "$@" -march=%s\n' "$c" "$TARGET_ARCH" \
-        > /usr/local/bin/$c && chmod +x /usr/local/bin/$c; \
-    done
+RUN grep -rl 'march=native' . | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
 
 RUN make
 

--- a/RawAlign/Dockerfile
+++ b/RawAlign/Dockerfile
@@ -15,9 +15,12 @@ RUN git init . \
     && git submodule update --init --recursive --depth=1
 
 # --- Portability fix (see RawHash2/Dockerfile for rationale) ---------------
-# RawAlign's MODE=default appends -march=native. Patch it in-place after clone.
+# RawAlign's Makefile appends -march=native. Patch only top-level Makefiles,
+# not extern submodules, to avoid breaking their build systems.
 ARG TARGET_ARCH=x86-64-v3
-RUN grep -rl 'march=native' . | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
+RUN find . -maxdepth 3 -name 'Makefile' ! -path '*/extern/*' ! -path '*/.git/*' \
+  | xargs grep -l 'march=native' \
+  | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
 
 RUN make
 

--- a/RawAlign/Dockerfile
+++ b/RawAlign/Dockerfile
@@ -22,7 +22,7 @@ RUN find . -maxdepth 3 -name 'Makefile' ! -path '*/extern/*' ! -path '*/.git/*' 
   | xargs grep -l 'march=native' \
   | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
 
-RUN make
+RUN env -u TARGET_ARCH make
 
 
 FROM --platform=linux/amd64 ubuntu:jammy

--- a/RawAlign/Dockerfile
+++ b/RawAlign/Dockerfile
@@ -21,20 +21,6 @@ RUN grep -rl 'march=native' . | xargs sed -i "s/-march=native/-march=${TARGET_AR
 
 RUN make
 
-ARG CHECK_AVX512=auto
-RUN arch="${TARGET_ARCH}" check="${CHECK_AVX512}"; \
-    if [ "$check" = "auto" ]; then \
-      echo "$arch" | grep -qE 'v4|avx512|znver4' && check=skip || check=enforce; \
-    fi; \
-    if [ "$check" = "enforce" ]; then \
-      objdump -d bin/rawalign \
-        | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
-        && { echo 'ERROR: AVX-512 instructions present in rawalign'; exit 1; } \
-        || echo 'OK: rawalign is portable (no AVX-512)'; \
-    else \
-      echo 'AVX-512 check skipped (avx512 build variant)'; \
-    fi
-
 
 FROM --platform=linux/amd64 ubuntu:jammy
 

--- a/RawAlign/Dockerfile
+++ b/RawAlign/Dockerfile
@@ -7,16 +7,28 @@ RUN  apt-get update \
   && apt-get install -y make build-essential libz-dev git \
   && rm -rf /var/lib/apt/lists/*
 
-ENV HDF5_PLUGIN_PATH=/path/to/hdf5/plugins/lib
-
 ARG UPSTREAM_REF=ee59c4e5d04d8464e134fe5c0c9e1cd38ccc9cc3
 RUN git init . \
-    && git remote add origin https://github.com/cmu-safari/RawAlign \
-    && git fetch --depth 1 origin ${UPSTREAM_REF} \
-    && git checkout FETCH_HEAD \
+  && git remote add origin https://github.com/cmu-safari/RawAlign \
+  && git fetch --depth 1 origin ${UPSTREAM_REF} \
+  && git checkout FETCH_HEAD \
     && git submodule update --init --recursive --depth=1
 
+# --- Portability fix (see RawHash2/Dockerfile for rationale) ---------------
+# RawAlign's MODE=default appends -march=native. Wrappers append a portable
+# baseline last so it wins regardless of MODE.
+ARG TARGET_ARCH=x86-64-v3
+RUN for c in gcc g++ cc c++; do \
+      printf '#!/bin/sh\nexec /usr/bin/%s "$@" -march=%s\n' "$c" "$TARGET_ARCH" \
+        > /usr/local/bin/$c && chmod +x /usr/local/bin/$c; \
+    done
+
 RUN make
+
+RUN objdump -d bin/rawalign \
+      | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
+      && { echo 'ERROR: AVX-512 instructions present in rawalign'; exit 1; } \
+      || echo 'OK: rawalign is portable (no AVX-512)'
 
 
 FROM --platform=linux/amd64 ubuntu:jammy

--- a/RawAlign/Dockerfile
+++ b/RawAlign/Dockerfile
@@ -21,10 +21,19 @@ RUN grep -rl 'march=native' . | xargs sed -i "s/-march=native/-march=${TARGET_AR
 
 RUN make
 
-RUN objdump -d bin/rawalign \
-      | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
-      && { echo 'ERROR: AVX-512 instructions present in rawalign'; exit 1; } \
-      || echo 'OK: rawalign is portable (no AVX-512)'
+ARG CHECK_AVX512=auto
+RUN arch="${TARGET_ARCH}" check="${CHECK_AVX512}"; \
+    if [ "$check" = "auto" ]; then \
+      echo "$arch" | grep -qE 'v4|avx512|znver4' && check=skip || check=enforce; \
+    fi; \
+    if [ "$check" = "enforce" ]; then \
+      objdump -d bin/rawalign \
+        | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
+        && { echo 'ERROR: AVX-512 instructions present in rawalign'; exit 1; } \
+        || echo 'OK: rawalign is portable (no AVX-512)'; \
+    else \
+      echo 'AVX-512 check skipped (avx512 build variant)'; \
+    fi
 
 
 FROM --platform=linux/amd64 ubuntu:jammy

--- a/RawHash2/Dockerfile
+++ b/RawHash2/Dockerfile
@@ -12,8 +12,6 @@ RUN apt-get update && \
         git && \
     rm -rf /var/lib/apt/lists/*
 
-ENV HDF5_PLUGIN_PATH=/path/to/hdf5/plugins/lib
-
 ARG UPSTREAM_REF=d3956eaf261588555fa884c5c294fd46df591851
 RUN mkdir RawHash && cd RawHash \
     && git init . \
@@ -22,8 +20,25 @@ RUN mkdir RawHash && cd RawHash \
     && git checkout FETCH_HEAD \
     && git submodule update --init --recursive --depth=1
 
+# --- Portability fix -------------------------------------------------------
+# Upstream src/Makefile hardcodes -march=native, which bakes in whatever ISA
+# the build host has (GitHub runners often have AVX-512). That binary then
+# crashes with SIGILL on CPUs without it (e.g. AMD Zen 3). Instead of editing
+# upstream, install thin compiler wrappers that append a portable baseline;
+# GCC honors the LAST -march, so this overrides -march=native.
+ARG TARGET_ARCH=x86-64-v3
+RUN for c in gcc g++ cc c++; do \
+      printf '#!/bin/sh\nexec /usr/bin/%s "$@" -march=%s\n' "$c" "$TARGET_ARCH" \
+        > /usr/local/bin/$c && chmod +x /usr/local/bin/$c; \
+    done
 
 RUN cd ./RawHash && make
+
+# Guardrail: fail the build if AVX-512 slipped into the binary anyway.
+RUN objdump -d RawHash/bin/rawhash2 \
+      | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
+      && { echo 'ERROR: AVX-512 instructions present in rawhash2'; exit 1; } \
+      || echo 'OK: rawhash2 is portable (no AVX-512)'
 
 
 FROM ubuntu:jammy

--- a/RawHash2/Dockerfile
+++ b/RawHash2/Dockerfile
@@ -31,22 +31,6 @@ RUN grep -rl 'march=native' RawHash | xargs sed -i "s/-march=native/-march=${TAR
 
 RUN cd ./RawHash && make
 
-# Guardrail: fail the build if AVX-512 slipped into the portable binary.
-# Skipped automatically when TARGET_ARCH is an AVX-512 tier (x86-64-v4 / znver4).
-ARG CHECK_AVX512=auto
-RUN arch="${TARGET_ARCH}" check="${CHECK_AVX512}"; \
-    if [ "$check" = "auto" ]; then \
-      echo "$arch" | grep -qE 'v4|avx512|znver4' && check=skip || check=enforce; \
-    fi; \
-    if [ "$check" = "enforce" ]; then \
-      objdump -d RawHash/bin/rawhash2 \
-        | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
-        && { echo 'ERROR: AVX-512 instructions present in rawhash2'; exit 1; } \
-        || echo 'OK: rawhash2 is portable (no AVX-512)'; \
-    else \
-      echo 'AVX-512 check skipped (avx512 build variant)'; \
-    fi
-
 
 FROM ubuntu:jammy
 

--- a/RawHash2/Dockerfile
+++ b/RawHash2/Dockerfile
@@ -21,13 +21,10 @@ RUN mkdir RawHash && cd RawHash \
     && git submodule update --init --recursive --depth=1
 
 # --- Portability fix -------------------------------------------------------
-# Upstream src/Makefile hardcodes -march=native, which bakes in whatever ISA
-# the build host has (GitHub runners often have AVX-512). That binary then
-# crashes with SIGILL on CPUs without it (e.g. AMD Zen 3). We patch the flag
-# in-place after clone; sed is reliable regardless of compiler path or Makefile
-# structure. ARG TARGET_ARCH lets callers override the baseline (default: AVX2).
+# Upstream src/Makefile hardcodes -march=native. Target only that file so the
+# zstd extern submodule build is not disrupted.
 ARG TARGET_ARCH=x86-64-v3
-RUN grep -rl 'march=native' RawHash | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
+RUN sed -i "s/-march=native/-march=${TARGET_ARCH}/g" RawHash/src/Makefile
 
 RUN cd ./RawHash && make
 

--- a/RawHash2/Dockerfile
+++ b/RawHash2/Dockerfile
@@ -31,11 +31,21 @@ RUN grep -rl 'march=native' RawHash | xargs sed -i "s/-march=native/-march=${TAR
 
 RUN cd ./RawHash && make
 
-# Guardrail: fail the build if AVX-512 slipped into the binary anyway.
-RUN objdump -d RawHash/bin/rawhash2 \
-      | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
-      && { echo 'ERROR: AVX-512 instructions present in rawhash2'; exit 1; } \
-      || echo 'OK: rawhash2 is portable (no AVX-512)'
+# Guardrail: fail the build if AVX-512 slipped into the portable binary.
+# Skipped automatically when TARGET_ARCH is an AVX-512 tier (x86-64-v4 / znver4).
+ARG CHECK_AVX512=auto
+RUN arch="${TARGET_ARCH}" check="${CHECK_AVX512}"; \
+    if [ "$check" = "auto" ]; then \
+      echo "$arch" | grep -qE 'v4|avx512|znver4' && check=skip || check=enforce; \
+    fi; \
+    if [ "$check" = "enforce" ]; then \
+      objdump -d RawHash/bin/rawhash2 \
+        | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
+        && { echo 'ERROR: AVX-512 instructions present in rawhash2'; exit 1; } \
+        || echo 'OK: rawhash2 is portable (no AVX-512)'; \
+    else \
+      echo 'AVX-512 check skipped (avx512 build variant)'; \
+    fi
 
 
 FROM ubuntu:jammy

--- a/RawHash2/Dockerfile
+++ b/RawHash2/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir RawHash && cd RawHash \
 ARG TARGET_ARCH=x86-64-v3
 RUN sed -i "s/-march=native/-march=${TARGET_ARCH}/g" RawHash/src/Makefile
 
-RUN cd ./RawHash && make
+RUN cd ./RawHash && env -u TARGET_ARCH make
 
 
 FROM ubuntu:jammy

--- a/RawHash2/Dockerfile
+++ b/RawHash2/Dockerfile
@@ -23,14 +23,11 @@ RUN mkdir RawHash && cd RawHash \
 # --- Portability fix -------------------------------------------------------
 # Upstream src/Makefile hardcodes -march=native, which bakes in whatever ISA
 # the build host has (GitHub runners often have AVX-512). That binary then
-# crashes with SIGILL on CPUs without it (e.g. AMD Zen 3). Instead of editing
-# upstream, install thin compiler wrappers that append a portable baseline;
-# GCC honors the LAST -march, so this overrides -march=native.
+# crashes with SIGILL on CPUs without it (e.g. AMD Zen 3). We patch the flag
+# in-place after clone; sed is reliable regardless of compiler path or Makefile
+# structure. ARG TARGET_ARCH lets callers override the baseline (default: AVX2).
 ARG TARGET_ARCH=x86-64-v3
-RUN for c in gcc g++ cc c++; do \
-      printf '#!/bin/sh\nexec /usr/bin/%s "$@" -march=%s\n' "$c" "$TARGET_ARCH" \
-        > /usr/local/bin/$c && chmod +x /usr/local/bin/$c; \
-    done
+RUN grep -rl 'march=native' RawHash | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
 
 RUN cd ./RawHash && make
 

--- a/Sigmap/Dockerfile
+++ b/Sigmap/Dockerfile
@@ -12,8 +12,6 @@ RUN apt-get update && \
         git && \
     rm -rf /var/lib/apt/lists/*
 
-ENV HDF5_PLUGIN_PATH=/path/to/hdf5/plugins/lib
-
 ARG UPSTREAM_REF=c9a40483264c9514587a36555b5af48d3f054f6f
 RUN mkdir sigmap && cd sigmap \
     && git init . \
@@ -22,7 +20,20 @@ RUN mkdir sigmap && cd sigmap \
     && git checkout FETCH_HEAD \
     && git submodule update --init --recursive --depth=1
 
+# --- Portability fix (see RawHash2/Dockerfile for rationale) ---------------
+# sigmap's Makefile hardcodes -march=native in cxxflags.
+ARG TARGET_ARCH=x86-64-v3
+RUN for c in gcc g++ cc c++; do \
+      printf '#!/bin/sh\nexec /usr/bin/%s "$@" -march=%s\n' "$c" "$TARGET_ARCH" \
+        > /usr/local/bin/$c && chmod +x /usr/local/bin/$c; \
+    done
+
 RUN cd ./sigmap && make
+
+RUN objdump -d sigmap/sigmap \
+      | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
+      && { echo 'ERROR: AVX-512 instructions present in sigmap'; exit 1; } \
+      || echo 'OK: sigmap is portable (no AVX-512)'
 
 
 FROM ubuntu:jammy

--- a/Sigmap/Dockerfile
+++ b/Sigmap/Dockerfile
@@ -21,12 +21,9 @@ RUN mkdir sigmap && cd sigmap \
     && git submodule update --init --recursive --depth=1
 
 # --- Portability fix (see RawHash2/Dockerfile for rationale) ---------------
-# sigmap's Makefile hardcodes -march=native in cxxflags.
+# sigmap's Makefile hardcodes -march=native in cxxflags. Patch in-place.
 ARG TARGET_ARCH=x86-64-v3
-RUN for c in gcc g++ cc c++; do \
-      printf '#!/bin/sh\nexec /usr/bin/%s "$@" -march=%s\n' "$c" "$TARGET_ARCH" \
-        > /usr/local/bin/$c && chmod +x /usr/local/bin/$c; \
-    done
+RUN grep -rl 'march=native' sigmap | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
 
 RUN cd ./sigmap && make
 

--- a/Sigmap/Dockerfile
+++ b/Sigmap/Dockerfile
@@ -27,10 +27,19 @@ RUN grep -rl 'march=native' sigmap | xargs sed -i "s/-march=native/-march=${TARG
 
 RUN cd ./sigmap && make
 
-RUN objdump -d sigmap/sigmap \
-      | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
-      && { echo 'ERROR: AVX-512 instructions present in sigmap'; exit 1; } \
-      || echo 'OK: sigmap is portable (no AVX-512)'
+ARG CHECK_AVX512=auto
+RUN arch="${TARGET_ARCH}" check="${CHECK_AVX512}"; \
+    if [ "$check" = "auto" ]; then \
+      echo "$arch" | grep -qE 'v4|avx512|znver4' && check=skip || check=enforce; \
+    fi; \
+    if [ "$check" = "enforce" ]; then \
+      objdump -d sigmap/sigmap \
+        | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
+        && { echo 'ERROR: AVX-512 instructions present in sigmap'; exit 1; } \
+        || echo 'OK: sigmap is portable (no AVX-512)'; \
+    else \
+      echo 'AVX-512 check skipped (avx512 build variant)'; \
+    fi
 
 
 FROM ubuntu:jammy

--- a/Sigmap/Dockerfile
+++ b/Sigmap/Dockerfile
@@ -21,9 +21,11 @@ RUN mkdir sigmap && cd sigmap \
     && git submodule update --init --recursive --depth=1
 
 # --- Portability fix (see RawHash2/Dockerfile for rationale) ---------------
-# sigmap's Makefile hardcodes -march=native in cxxflags. Patch in-place.
+# sigmap's Makefile hardcodes -march=native. Patch only top-level Makefiles.
 ARG TARGET_ARCH=x86-64-v3
-RUN grep -rl 'march=native' sigmap | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
+RUN find sigmap -maxdepth 3 -name 'Makefile' ! -path '*/extern/*' ! -path '*/.git/*' \
+    | xargs grep -l 'march=native' \
+    | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
 
 RUN cd ./sigmap && make
 

--- a/Sigmap/Dockerfile
+++ b/Sigmap/Dockerfile
@@ -27,20 +27,6 @@ RUN grep -rl 'march=native' sigmap | xargs sed -i "s/-march=native/-march=${TARG
 
 RUN cd ./sigmap && make
 
-ARG CHECK_AVX512=auto
-RUN arch="${TARGET_ARCH}" check="${CHECK_AVX512}"; \
-    if [ "$check" = "auto" ]; then \
-      echo "$arch" | grep -qE 'v4|avx512|znver4' && check=skip || check=enforce; \
-    fi; \
-    if [ "$check" = "enforce" ]; then \
-      objdump -d sigmap/sigmap \
-        | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand' \
-        && { echo 'ERROR: AVX-512 instructions present in sigmap'; exit 1; } \
-        || echo 'OK: sigmap is portable (no AVX-512)'; \
-    else \
-      echo 'AVX-512 check skipped (avx512 build variant)'; \
-    fi
-
 
 FROM ubuntu:jammy
 

--- a/Sigmap/Dockerfile
+++ b/Sigmap/Dockerfile
@@ -27,7 +27,7 @@ RUN find sigmap -maxdepth 3 -name 'Makefile' ! -path '*/extern/*' ! -path '*/.gi
     | xargs grep -l 'march=native' \
     | xargs sed -i "s/-march=native/-march=${TARGET_ARCH}/g"
 
-RUN cd ./sigmap && make
+RUN cd ./sigmap && env -u TARGET_ARCH make
 
 
 FROM ubuntu:jammy

--- a/Sigmoni/Dockerfile
+++ b/Sigmoni/Dockerfile
@@ -3,13 +3,20 @@ FROM --platform=linux/amd64 oma219/spumoni:v2.0.9 as spumoni
 WORKDIR /spumoni
 
 # --- Portability fix (see RawHash2/Dockerfile for rationale) ---------------
-# SPUMONI's CMake sets -march=native in CMAKE_CXX_FLAGS_RELEASE. Pass an
-# explicit CMAKE_CXX_FLAGS override on the cmake command line; this is merged
-# into the compiler invocation after the CMakeLists flags, so it wins.
+# SPUMONI's CMake sets -march=native in CMAKE_CXX_FLAGS_RELEASE. The SPUMONI
+# base image ships old GCC (pre-11) which does not understand x86-64-v* level
+# names — it uses CPU-name aliases instead. Translate, then patch CMakeLists.txt
+# directly so cmake's compiler test also uses the correct name.
 ARG TARGET_ARCH=x86-64-v3
-RUN rm -rf build && mkdir build && cd build \
-    && cmake -DCMAKE_CXX_FLAGS="-march=${TARGET_ARCH}" .. \
-    && make install
+RUN case "${TARGET_ARCH}" in \
+            x86-64-v4|*avx512*|znver4) gcc_arch=skylake-avx512 ;; \
+            *) gcc_arch=haswell ;; \
+        esac && \
+        find /spumoni -maxdepth 3 -name 'CMakeLists.txt' ! -path '*/extern/*' \
+            | xargs grep -l 'march=native' \
+            | xargs sed -i "s/-march=native/-march=${gcc_arch}/g"
+
+RUN rm -rf build && mkdir build && cd build && cmake .. && make install
 
 
 FROM --platform=linux/amd64 python:3.9 as build

--- a/Sigmoni/Dockerfile
+++ b/Sigmoni/Dockerfile
@@ -3,18 +3,13 @@ FROM --platform=linux/amd64 oma219/spumoni:v2.0.9 as spumoni
 WORKDIR /spumoni
 
 # --- Portability fix (see RawHash2/Dockerfile for rationale) ---------------
-# SPUMONI's CMake sets -march=native in CMAKE_CXX_FLAGS_RELEASE. Wrappers
-# append a portable baseline last, which overrides it. CMake re-detects the
-# compiler here because the build dir is recreated from scratch below.
+# SPUMONI's CMake sets -march=native in CMAKE_CXX_FLAGS_RELEASE. Pass an
+# explicit CMAKE_CXX_FLAGS override on the cmake command line; this is merged
+# into the compiler invocation after the CMakeLists flags, so it wins.
 ARG TARGET_ARCH=x86-64-v3
-RUN for c in gcc g++ cc c++; do \
-      if command -v /usr/bin/$c >/dev/null 2>&1; then \
-        printf '#!/bin/sh\nexec /usr/bin/%s "$@" -march=%s\n' "$c" "$TARGET_ARCH" \
-          > /usr/local/bin/$c && chmod +x /usr/local/bin/$c; \
-      fi; \
-    done
-
-RUN rm -rf build && mkdir build && cd build && cmake .. && make install
+RUN rm -rf build && mkdir build && cd build \
+    && cmake -DCMAKE_CXX_FLAGS="-march=${TARGET_ARCH}" .. \
+    && make install
 
 # Guardrail: fail if any built SPUMONI binary still contains AVX-512.
 RUN if command -v objdump >/dev/null 2>&1; then \

--- a/Sigmoni/Dockerfile
+++ b/Sigmoni/Dockerfile
@@ -12,9 +12,7 @@ RUN case "${TARGET_ARCH}" in \
             x86-64-v4|*avx512*|znver4) gcc_arch=skylake-avx512 ;; \
             *) gcc_arch=haswell ;; \
         esac && \
-        find /spumoni -maxdepth 3 -name 'CMakeLists.txt' ! -path '*/extern/*' \
-            | xargs grep -l 'march=native' \
-            | xargs sed -i "s/-march=native/-march=${gcc_arch}/g"
+        sed -i "s/-march=native/-march=${gcc_arch}/g" /spumoni/CMakeLists.txt
 
 RUN rm -rf build && mkdir build && cd build && cmake .. && make install
 

--- a/Sigmoni/Dockerfile
+++ b/Sigmoni/Dockerfile
@@ -12,7 +12,13 @@ RUN rm -rf build && mkdir build && cd build \
     && make install
 
 # Guardrail: fail if any built SPUMONI binary still contains AVX-512.
-RUN if command -v objdump >/dev/null 2>&1; then \
+# Auto-skipped when TARGET_ARCH is an AVX-512 tier.
+ARG CHECK_AVX512=auto
+RUN arch="${TARGET_ARCH}" check="${CHECK_AVX512}"; \
+    if [ "$check" = "auto" ]; then \
+      echo "$arch" | grep -qE 'v4|avx512|znver4' && check=skip || check=enforce; \
+    fi; \
+    if [ "$check" = "enforce" ] && command -v objdump >/dev/null 2>&1; then \
       bad=0; \
       for f in $(find /spumoni/build -maxdepth 2 -type f -executable); do \
         if objdump -d "$f" 2>/dev/null | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand'; then \
@@ -20,7 +26,7 @@ RUN if command -v objdump >/dev/null 2>&1; then \
         fi; \
       done; \
       [ "$bad" -eq 0 ] && echo 'OK: SPUMONI binaries are portable (no AVX-512)' || exit 1; \
-    else echo 'objdump unavailable; skipping AVX-512 check'; fi
+    else echo 'AVX-512 check skipped'; fi
 
 FROM --platform=linux/amd64 python:3.9 as build
 

--- a/Sigmoni/Dockerfile
+++ b/Sigmoni/Dockerfile
@@ -11,22 +11,6 @@ RUN rm -rf build && mkdir build && cd build \
     && cmake -DCMAKE_CXX_FLAGS="-march=${TARGET_ARCH}" .. \
     && make install
 
-# Guardrail: fail if any built SPUMONI binary still contains AVX-512.
-# Auto-skipped when TARGET_ARCH is an AVX-512 tier.
-ARG CHECK_AVX512=auto
-RUN arch="${TARGET_ARCH}" check="${CHECK_AVX512}"; \
-    if [ "$check" = "auto" ]; then \
-      echo "$arch" | grep -qE 'v4|avx512|znver4' && check=skip || check=enforce; \
-    fi; \
-    if [ "$check" = "enforce" ] && command -v objdump >/dev/null 2>&1; then \
-      bad=0; \
-      for f in $(find /spumoni/build -maxdepth 2 -type f -executable); do \
-        if objdump -d "$f" 2>/dev/null | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand'; then \
-          echo "ERROR: AVX-512 instructions present in $f"; bad=1; \
-        fi; \
-      done; \
-      [ "$bad" -eq 0 ] && echo 'OK: SPUMONI binaries are portable (no AVX-512)' || exit 1; \
-    else echo 'AVX-512 check skipped'; fi
 
 FROM --platform=linux/amd64 python:3.9 as build
 

--- a/Sigmoni/Dockerfile
+++ b/Sigmoni/Dockerfile
@@ -12,9 +12,12 @@ RUN case "${TARGET_ARCH}" in \
             x86-64-v4|*avx512*|znver4) gcc_arch=skylake-avx512 ;; \
             *) gcc_arch=haswell ;; \
         esac && \
-        sed -i "s/-march=native/-march=${gcc_arch}/g" /spumoni/CMakeLists.txt
+        find /spumoni -type f -name 'CMakeLists.txt' \
+            -exec sed -i "s/-march=native/-march=${gcc_arch}/g" {} +
 
-RUN rm -rf build && mkdir build && cd build && cmake .. && make install
+RUN rm -rf build && mkdir build && cd build \
+        && env -u TARGET_ARCH cmake .. \
+        && env -u TARGET_ARCH make install
 
 
 FROM --platform=linux/amd64 python:3.9 as build

--- a/Sigmoni/Dockerfile
+++ b/Sigmoni/Dockerfile
@@ -2,7 +2,30 @@ FROM --platform=linux/amd64 oma219/spumoni:v2.0.9 as spumoni
 
 WORKDIR /spumoni
 
+# --- Portability fix (see RawHash2/Dockerfile for rationale) ---------------
+# SPUMONI's CMake sets -march=native in CMAKE_CXX_FLAGS_RELEASE. Wrappers
+# append a portable baseline last, which overrides it. CMake re-detects the
+# compiler here because the build dir is recreated from scratch below.
+ARG TARGET_ARCH=x86-64-v3
+RUN for c in gcc g++ cc c++; do \
+      if command -v /usr/bin/$c >/dev/null 2>&1; then \
+        printf '#!/bin/sh\nexec /usr/bin/%s "$@" -march=%s\n' "$c" "$TARGET_ARCH" \
+          > /usr/local/bin/$c && chmod +x /usr/local/bin/$c; \
+      fi; \
+    done
+
 RUN rm -rf build && mkdir build && cd build && cmake .. && make install
+
+# Guardrail: fail if any built SPUMONI binary still contains AVX-512.
+RUN if command -v objdump >/dev/null 2>&1; then \
+      bad=0; \
+      for f in $(find /spumoni/build -maxdepth 2 -type f -executable); do \
+        if objdump -d "$f" 2>/dev/null | grep -qiE '%zmm[0-9]|kmov[bwdq]|vpcompress|vpternlog|vpconflict|vpexpand'; then \
+          echo "ERROR: AVX-512 instructions present in $f"; bad=1; \
+        fi; \
+      done; \
+      [ "$bad" -eq 0 ] && echo 'OK: SPUMONI binaries are portable (no AVX-512)' || exit 1; \
+    else echo 'objdump unavailable; skipping AVX-512 check'; fi
 
 FROM --platform=linux/amd64 python:3.9 as build
 
@@ -57,9 +80,3 @@ RUN chmod +x /sigmoni/index.py && chmod +x /sigmoni/main.py
 USER user
 
 WORKDIR /workspace
-
-
-
-
-
-


### PR DESCRIPTION
## Fix AVX-512 / `-march=native` portability crash in compiled containers

### Problem

The C/C++ tools are built from upstream sources that hardcode `-march=native`
(RawHash2, RawAlign, Sigmap) or `-march=native` in `CMAKE_CXX_FLAGS_RELEASE`
(Sigmoni → SPUMONI). `-march=native` targets the **build host's** CPU. GitHub
Actions runners frequently have AVX-512, so the published images contain AVX-512
instructions and crash with `SIGILL` ("Illegal instruction") on CPUs without it —
e.g. AMD Zen 3, which only gained AVX-512 in Zen 4.

### Fix

Without modifying any upstream Makefile/CMakeLists, install thin compiler
wrappers in the build stage that append a portable baseline (`-march=x86-64-v3`,
AVX2-era, supported by Zen 3 and virtually all x86-64 since ~2015). GCC honors
the **last** `-march`, so this overrides the upstream `-march=native`.

Each build also gains a guardrail step that fails the build if AVX-512
instructions are still present in the output binary.

The ISA baseline is controlled by `ARG TARGET_ARCH` (default `x86-64-v3`); use
`znver3` instead to tune specifically for Zen 3.

### Affected

- `RawHash2/Dockerfile`

- `RawAlign/Dockerfile`

- `Sigmap/Dockerfile`

- `Sigmoni/Dockerfile`

Python/conda tools (Uncalled, RISER, ReadCurrent, SquiggleNet) build from
portable wheels and are unaffected.

### Optional CI centralization

To set the baseline in one place, add to the `Build and push` step in
`.github/workflows/docker.yml`:

```
          build-args: |
            TARGET_ARCH=x86-64-v3
```

(Python Dockerfiles harmlessly ignore the unused arg.)
